### PR TITLE
Add `output_type_id_datatype` property

### DIFF
--- a/hub-config/admin.json
+++ b/hub-config/admin.json
@@ -1,5 +1,5 @@
 {
-    "schema_version": "https://raw.githubusercontent.com/hubverse-org/schemas/main/v3.0.0/admin-schema.json",
+    "schema_version": "https://raw.githubusercontent.com/hubverse-org/schemas/main/v3.0.1/admin-schema.json",
     "name": "Template Forecast Hub",
     "maintainer": "Consortium of Infectious Disease Modeling Hubs",
     "contact": {

--- a/hub-config/model-metadata-schema.json
+++ b/hub-config/model-metadata-schema.json
@@ -80,12 +80,16 @@
         "citation": {
             "description": "One or more citations for this model",
             "type": "string",
-            "examples": "Gibson GC , Reich NG , Sheldon D. Real-time mechanistic bayesian forecasts of Covid-19 mortality. medRxiv. 2020. https://doi.org/10.1101/2020.12.22.20248736"
+            "examples": [
+                "Gibson GC , Reich NG , Sheldon D. Real-time mechanistic bayesian forecasts of Covid-19 mortality. medRxiv. 2020. https://doi.org/10.1101/2020.12.22.20248736"
+            ]
         },
         "team_funding": {
             "description": "Any information about funding source for the team or members of the team.",
             "type": "string",
-            "examples": "National Institutes of General Medical Sciences (R01GM123456). The content is solely the responsibility of the authors and does not necessarily represent the official views of NIGMS."
+            "examples": [
+                "National Institutes of General Medical Sciences (R01GM123456). The content is solely the responsibility of the authors and does not necessarily represent the official views of NIGMS."
+            ]
         },
         "model_details": {
             "description": "Structured information about the model",

--- a/hub-config/tasks.json
+++ b/hub-config/tasks.json
@@ -1,5 +1,5 @@
 {
-    "schema_version": "https://raw.githubusercontent.com/hubverse-org/schemas/main/v3.0.0/tasks-schema.json",
+    "schema_version": "https://raw.githubusercontent.com/hubverse-org/schemas/main/v3.0.1/tasks-schema.json",
     "rounds": [
         {
             "round_id_from_variable": true,
@@ -21,5 +21,6 @@
                 "end": "2900-12-31"
             }
         }
-    ]
+    ],
+    "output_type_id_datatype": "auto"
 }


### PR DESCRIPTION
In v3.0.1 of the schema, the optional `output_type_id_datatype` property was introduced to enable hub administrators to configure and communicate the `output_type_id` column data type at a hub level. This property allows hubs to override default behaviour of automatically determining the simplest data type that can accomodate output type IDs across all output types when creating hub schema. 

The setting is also useful for administrators to future proof the `output_type_id` column from potential issues arising by changes in data type, introduced by new output types after submissions have begun, by setting `output_type_id_datatype` to the simplest data type from the start, i.e. character.

If the property is not provided or set to `"auto"` (the default), the hub uses autodetection to determine the simplest hub level data type that can represent all output type ID values across all hub output types and rounds.

Resolves #18 

Also resolves #12 