### PR TITLE
Bump version to v4.0.0. Add `null` `derived_task_ids` property

### DIFF
--- a/hub-config/admin.json
+++ b/hub-config/admin.json
@@ -1,5 +1,5 @@
 {
-    "schema_version": "https://raw.githubusercontent.com/hubverse-org/schemas/main/v3.0.1/admin-schema.json",
+    "schema_version": "https://raw.githubusercontent.com/hubverse-org/schemas/main/v4.0.0/admin-schema.json",
     "name": "Template Forecast Hub",
     "maintainer": "Consortium of Infectious Disease Modeling Hubs",
     "contact": {

--- a/hub-config/tasks.json
+++ b/hub-config/tasks.json
@@ -1,5 +1,5 @@
 {
-    "schema_version": "https://raw.githubusercontent.com/hubverse-org/schemas/main/v3.0.1/tasks-schema.json",
+    "schema_version": "https://raw.githubusercontent.com/hubverse-org/schemas/main/v4.0.0/tasks-schema.json",
     "rounds": [
         {
             "round_id_from_variable": true,
@@ -22,5 +22,6 @@
             }
         }
     ],
-    "output_type_id_datatype": "auto"
+    "output_type_id_datatype": "auto",
+    "derived_task_ids": null
 }


### PR DESCRIPTION
To be merged and a new release created only once v4 schema is released