### PR TITLE
Add section about cloud access to the hub template

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,19 @@
+repos:
+- repo: https://github.com/pre-commit/pre-commit-hooks
+  rev: v4.6.0
+  hooks:
+  - id: trailing-whitespace
+  - id: check-yaml
+    args: [--allow-multiple-documents]
+  - id: detect-aws-credentials
+    args: [--allow-missing-credentials]
+  - id: detect-private-key
+- repo: https://github.com/igorshubovych/markdownlint-cli
+  rev: v0.41.0
+  hooks:
+  - id: markdownlint
+    args: [ --fix, --disable=MD007, --disable=MD013, --disable=MD041 ]
+- repo: https://github.com/codespell-project/codespell
+  rev: v2.3.0
+  hooks:
+  - id: codespell

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -12,7 +12,7 @@ repos:
   rev: v0.41.0
   hooks:
   - id: markdownlint
-    args: [ --fix, --disable=MD007, --disable=MD013, --disable=MD041 ]
+    args: [ --fix, --disable=MD007, --disable=MD013, --disable=MD024, --disable=MD033, --disable=MD041 ]
 - repo: https://github.com/codespell-project/codespell
   rev: v2.3.0
   hooks:

--- a/README.md
+++ b/README.md
@@ -89,7 +89,7 @@ hubData is a good choice if you:
 
 ### Installing hubData
 
-To install hubData, follow the [instructions in its documentation](https://hubverse-org.github.io/hubData/#installation).
+To install hubData and its dependencies (including the dplyr and arrow packages), follow the [instructions in the hubData documentation](https://hubverse-org.github.io/hubData/#installation).
 
 ### Using hubData
 

--- a/README.md
+++ b/README.md
@@ -93,10 +93,11 @@ To install hubData and its dependencies (including the dplyr and arrow packages)
 
 ### Using hubData
 
-hubData's [`connect_hub` function](https://hubverse-org.github.io/hubData/reference/connect_hub.html) returns an Arrow
-[multi-file dataset](https://arrow.apache.org/docs/r/reference/Dataset.html) that represents a hub's model output data.
+hubData's [`connect_hub()` function](https://hubverse-org.github.io/hubData/reference/connect_hub.html) returns an [Arrow
+multi-file dataset](https://arrow.apache.org/docs/r/reference/Dataset.html) that represents a hub's model output data.
 The dataset can be filtered and transformed using dplyr and then materialized into a local data frame
-using [`collect_hub`](https://hubverse-org.github.io/hubData/reference/collect_hub.html).
+using the [`collect_hub()` function](https://hubverse-org.github.io/hubData/reference/collect_hub.html).
+
 
 #### Accessing target data
 

--- a/README.md
+++ b/README.md
@@ -1,27 +1,43 @@
-<mark style="background-color: #FFE331">**Below is a template of the README.md file for your hub. Italics in brackets are placeholders for information about your hub.  **</mark>
-
+<mark style="background-color: #FFE331">**Below is a template of the README.md file for your hub. Italics in brackets are placeholders for information about your hub.**</mark>
 
 # *[Insert title of hub]*
-*[Describe overall purpose of hub.]* Anyone interested in using these data for additional research or publications is requested to contact *[insert email]* for information regarding attribution of the source forecasts.
+
+*[Describe overall purpose of hub.]* Anyone interested in using these data for additional research or publications is
+requested to contact *[insert email]* for information regarding attribution of the source forecasts.
 
 ## *[Insert title of forecasts]*
-*[Describe forecasts ]*
 
-**Dates:** The Challenge Period will begin *[insert start date]* and will run until *[insert start date]*. Participants are currently asked to submit *[insert description of forecasts]*  by *[insert timing]* .(herein referred to as the Forecast Due Date). In the event that timelines of data availability change, *[insert name of hub]*  may change the day of week that forecasts are due. In this case, participants would be notified at least one week in advance. *[insert temporal period]*  submissions (including file names) will be specified in terms of the reference date, which is the Saturday following the Forecast Due Date. The reference date is the last day of the epidemiological week (EW) (Sunday to Saturday) containing the Forecast Due Date.
+*[Describe forecasts]*
+
+**Dates:** The Challenge Period will begin *[insert start date]* and will run until *[insert start date]*. Participants
+are currently asked to submit *[insert description of forecasts]*  by *[insert timing]* .(herein referred to as the
+Forecast Due Date). In the event that timelines of data availability change, *[insert name of hub]*  may change the
+day of week that forecasts are due. In this case, participants would be notified at least one week in advance.
+*[insert temporal period]* submissions (including file names) will be specified in terms of the reference date, which
+is the Saturday following the Forecast Due Date. The reference date is the last day of the epidemiological week (EW)
+(Sunday to Saturday) containing the Forecast Due Date.
 
 **Prediction Targets:**
-Participating teams are asked to provide *[insert geographical requirements]*  predictions for  targets *[insert name of target(s)]*. 
+Participating teams are asked to provide *[insert geographical requirements]* predictions for targets
+*[insert name of target(s)]*.
 
-Teams will submit  *[insert description of forecasts]* for the epidemiological week (EW) ending on the reference date as well as  *[insert horizons]*. Teams can but are not required to submit forecasts for all *[insert temporal period]* horizons or for all locations. The evaluation data for forecasts will be the *[insert temporal period]* aggregate of *[insert description of evaluation data]*  We will use the specification of EWs defined by the [CDC](https://wwwn.cdc.gov/nndss/document/MMWR_Week_overview.pdf), which run Sunday through Saturday. The target end date for a prediction is the Saturday that ends an EW of interest, and can be calculated using the expression: 
+Teams will submit *[insert description of forecasts]* for the epidemiological week (EW) ending on the reference date
+as well as *[insert horizons]*. Teams can but are not required to submit forecasts for all *[insert temporal period]*
+horizons or for all locations. The evaluation data for forecasts will be the *[insert temporal period]* aggregate of
+*[insert description of evaluation data]*. We will use the specification of EWs defined by the
+[CDC](https://wwwn.cdc.gov/nndss/document/MMWR_Week_overview.pdf), which run Sunday through Saturday. The target end
+date for a prediction is the Saturday that ends an EW of interest, and can be calculated using the expression:
 **target end date = reference date + horizon * (*[insert # days in temporal period]* days)**.
 
-There are standard software packages to convert from dates to epidemic weeks and vice versa (e.g. [MMWRweek](https://cran.r-project.org/web/packages/MMWRweek/) and [lubridate](https://lubridate.tidyverse.org/reference/week.html) for R and [pymmwr](https://pypi.org/project/pymmwr/) and [epiweeks](https://pypi.org/project/epiweeks/) for Python). 
+There are standard software packages to convert from dates to epidemic weeks and vice versa (*e.g.*,
+[MMWRweek](https://cran.r-project.org/web/packages/MMWRweek/) and
+[lubridate](https://lubridate.tidyverse.org/reference/week.html) for R and [pymmwr](https://pypi.org/project/pymmwr/)
+and [epiweeks](https://pypi.org/project/epiweeks/) for Python).
 
-
-If you have questions aboutthis target, please reach out to *[insert name]*  (*[insert email]* ). 
+If you have questions aboutthis target, please reach out to *[insert name]* (*[insert email]*).
 
 ## Acknowledgments
-This repository follows the guidelines and standards outlined by the [hubverse]([url](https://hubverse.io/en/latest/)), which provides a set of data formats and open source tools for modeling hubs.
 
-
-<mark style="background-color: #FFE331">**As an example, here is the link to [Flusight-Forecast_Hub  README](https://github.com/cdcepi/FluSight-forecast-hub/blob/master/README.md).  **</mark>
+This repository follows the guidelines and standards outlined by the
+[hubverse]([url](https://hubverse.io/en/latest/)), which provides a set of data formats and open source tools
+for modeling hubs.

--- a/README.md
+++ b/README.md
@@ -42,6 +42,231 @@ and [epiweeks](https://pypi.org/project/epiweeks/) for Python).
 
 If you have questions aboutthis target, please reach out to *[insert name]* (*[insert email]*).
 
+## Accessing hub data on the cloud
+
+*[Remove this section if you're not planning to host your hub's data on the Hubverse's AWS infrastructure]*
+
+To ensure greater access to the data created by and submitted to this hub, real-time copies of its model-output,
+target, and configuration files are hosted on the Hubverse's Amazon Web Services (AWS) infrastructure,
+in a public S3 bucket:
+*[insert S3 bucket name, as specified in admin.json cloud.host.storage_location]*
+
+**Note**: For efficient storage, all model-output files in S3 are stored in parquet format, even if the original
+versions in the GitHub repository are .csv.
+
+GitHub remains the primary interface for operating the hub and collecting forecasts from modelers.
+However, the mirrors of hub files on S3 are the most convenient way to access hub data without using git/GitHub or
+cloning the entire hub to your local machine.
+
+The sections below provide examples for accessing hub data on the cloud, depending on your goals and
+preferred tools. The options include:
+
+| Access Method              | Description                                                                           |
+| -------------------------- | ------------------------------------------------------------------------------------- |
+| hubData (R)                | Hubverse R client and R code for accessing hub data                                   |
+| Polars (Python)            | Python open-source library for data manipulation                                      |
+| AWS command line interface | Download hub data to your machine and use hubData or Polars for local access          |
+
+In general, accessing the data directly from S3 (instead of downloading it first) is more convenient. However, if
+performance is critical (for example, you're building an interactive visualization), or if you need to work offline,
+we recommend downloading the data first.
+
+<!-------------------------------------------------- hubData ------------------------------------------------------->
+
+<details>
+
+<summary>hubData (R)</summary>
+
+[hubData](https://hubverse-org.github.io/hubData), the Hubverse R client, can create an interactive session
+for accessing, filtering, and transforming hub model output data stored in S3.
+
+hubData is a good choice if you:
+
+- already use R for data analysis
+- want to interactively explore hub data from the cloud without downloading it
+- want to save a subset of the hub's data (*e.g.*, forecasts for a specific date or target) to your local machine
+- want to save hub data in a different file format (*e.g.*, parquet to .csv)
+
+### Installing hubData
+
+To install hubData, follow the [instructions in its documentation](https://hubverse-org.github.io/hubData/#installation).
+
+### Using hubData
+
+hubData's [`connect_hub` function](https://hubverse-org.github.io/hubData/reference/connect_hub.html) returns an Arrow
+[multi-file dataset](https://arrow.apache.org/docs/r/reference/Dataset.html) that represents a hub's model output data.
+The dataset can be filtered and transformed using dplyr and then materialized into a local data frame
+using [`collect_hub`](https://hubverse-org.github.io/hubData/reference/collect_hub.html).
+
+#### Accessing target data
+
+*[hubData will be updated to access target data once the Hubverse target data standards are finalized.]*
+
+#### Accessing model output data
+
+Below is an example of using hubData to connect to a hub on S3 and filter the model output data.
+
+```r
+library(dplyr)
+library(hubData)
+
+hub_bucket <- s3_bucket([hub-bucket-name])
+hub_con <- hubData::connect_hub(hub_bucket, file_format="parquet", skip_checks=TRUE)
+hub_con %>%
+  dplyr::filter(location=="MA", output_type=="quantile") %>%
+  hubData::collect_hub()
+```
+
+- [full hubData documentation](https://hubverse-org.github.io/hubData/)
+
+</details>
+
+<!--------------------------------------------------- Polars ------------------------------------------------------->
+
+<details>
+
+<summary>Polars (Python)</summary>
+
+The Hubverse team is currently developing a Python client (hubDataPy). Until hubDataPy is ready,
+the [Polars](https://pola.rs/) library is a good option for working with hub data in S3.
+Similar to pandas, Polars is based on dataframes and series. However, Polars has a more straightforward API and is
+designed to work with larger-than-memory datasets.
+
+Pandas users can access hub data as described below and then use the `to_pandas()` method to convert a Polars dataframe
+to pandas format.
+
+Polars is a good choice if you:
+
+- already use Python for data analysis
+- want to interactively explore hub data from the cloud without downloading it
+- want to save a subset of the hub's data (*e.g.*, forecasts for a specific date or target) to your local machine
+- want to save hub data in a different file format (*e.g.*, parquet to .csv)
+
+### Installing polars
+
+Use pip to install Polars:
+
+```sh
+pip install polars
+```
+
+### Using Polars
+
+The examples below use the Polars
+[`scan_parquet`](https://docs.pola.rs/api/python/dev/reference/api/polars.scan_parquet.html) function, which returns a
+[LazyFrame](https://docs.pola.rs/api/python/stable/reference/lazyframe/index.html).
+LazyFrames do not perform computations until necessary, so any filtering and transforms you apply to the data are
+deferred until an explicit
+[`collect()` operation](https://docs.pola.rs/api/python/stable/reference/lazyframe/api/polars.LazyFrame.collect.html#polars.LazyFrame.collect).
+
+#### Accessing target data
+
+Get all oracle-output files into a single DataFrame.
+
+```python
+import polars as pl
+
+oracle_data = pl.scan_parquet(
+    # the structure of the s3 link below will depend on how your hub organizes target data
+    "s3://[hub-bucket-name]/target-data/oracle-output/*/*.parquet",
+    storage_options={"skip_signature": "true"}
+)
+
+# filter and transform as needed and collect into a dataframe, for example:
+oracle_dataframe = oracle_data.filter(pl.col("location") == "MA").collect()
+```
+
+#### Accessing model output data
+
+Get the model-output files for a specific team (all rounds).
+This example uses
+[glob patterns to read from data multiple files into a single dataset](https://docs.pola.rs/user-guide/io/multiple/#reading-into-a-single-dataframe).
+
+```python
+import polars as pl
+
+lf = pl.scan_parquet(
+    "s3://[hub-bucket-name]/model-output/[modeling team name]/*.parquet",
+    storage_options={"skip_signature": "true"}
+)
+```
+
+#### Using partitions (hive-style)
+
+If your data uses hive-style partitioning, Polars can use the partitions to filter the data before reading it.
+
+```python
+from datetime import datetime
+import polars as pl
+
+oracle_data = pl.scan_parquet(
+    "s3://[hub-bucket-name]/target-data/oracle-output/",
+    hive_partitioning=True,
+    storage_options={"skip_signature": "true"}) \
+.filter(pl.col("nowcast_date") == datetime(2025, 2, 5)) \
+.collect()
+```
+
+- [Full documentation of the Polars Python API](https://docs.pola.rs/api/python/stable/reference/)
+
+</details>
+
+<!--------------------------------------------------- AWS CLI ------------------------------------------------------->
+
+<details>
+
+<summary>AWS CLI</summary>
+
+AWS provides a terminal-based command line interface (CLI) for exploring and downloading S3 files.
+This option is ideal if you:
+
+- plan to work with hub data offline but don't want to use git or GitHub
+- want to download a subset of the data (instead of the entire hub)
+- are using the data for an application that requires local storage or fast response times
+
+### Installing the AWS CLI
+
+- Install the AWS CLI using the
+[instructions here](https://docs.aws.amazon.com/cli/latest/userguide/getting-started-install.html)
+- You can skip the instructions for setting up security credentials, since Hubverse data is public
+
+### Using the AWS CLI
+
+When using the AWS CLI, the `--no-sign-request` option is required, since it tells AWS to bypass a credential check
+(*i.e.*, `--no-sign-request` allows anonymous access to public S3 data).
+
+> [!NOTE]
+> Files in the bucket's `raw` directory should not be used for analysis (they're for internal use only).
+
+List all directories in the hub's S3 bucket:
+
+```sh
+aws s3 ls [hub-bucket-name] --no-sign-request
+```
+
+List all files in the hub's bucket:
+
+```sh
+aws s3 ls [hub-bucket-name] --recursive --no-sign-request
+```
+
+Download all of target-data contents to your current working directory:
+
+```sh
+aws s3 cp s3://[hub-bucket-name]/target-data/ . --recursive --no-sign-request
+```
+
+Download the model-output files for a specific team:
+
+```sh
+aws s3 cp s3://[hub-bucket-name]/[modeling-team-name]/UMass-flusion/ . --recursive --no-sign-request
+```
+
+- [Full documentation for `aws s3 ls`](https://docs.aws.amazon.com/cli/latest/reference/s3/ls.html)
+- [Full documentation for `aws s3 cp`](https://docs.aws.amazon.com/cli/latest/reference/s3/cp.html)
+
+</details>
+
 ## Acknowledgments
 
 This repository follows the guidelines and standards outlined by the

--- a/README.md
+++ b/README.md
@@ -271,6 +271,7 @@ aws s3 cp s3://[hub-bucket-name]/[modeling-team-name]/UMass-flusion/ . --recursi
 
 ## Acknowledgments
 
-This repository follows the guidelines and standards outlined by the
-[hubverse]([url](https://hubverse.io/en/latest/)), which provides a set of data formats and open source tools
+This repository follows the guidelines and standards outlined by [the
+[hubverse](https://hubverse.io/en/latest/), which provides a set of data formats and open source tools
+
 for modeling hubs.

--- a/README.md
+++ b/README.md
@@ -111,7 +111,8 @@ Below is an example of using hubData to connect to a hub on S3 and filter the mo
 library(dplyr)
 library(hubData)
 
-hub_bucket <- s3_bucket([hub-bucket-name])
+bucket_name <- "hub-bucket-name"
+hub_bucket <- s3_bucket(bucket_name)
 hub_con <- hubData::connect_hub(hub_bucket, file_format = "parquet", skip_checks = TRUE)
 hub_con %>%
   dplyr::filter(location == "MA", output_type == "quantile") %>%

--- a/README.md
+++ b/README.md
@@ -155,7 +155,7 @@ pip install polars
 ### Using Polars
 
 The examples below use the Polars
-[`scan_parquet`](https://docs.pola.rs/api/python/dev/reference/api/polars.scan_parquet.html) function, which returns a
+[`scan_parquet()` function](https://docs.pola.rs/api/python/dev/reference/api/polars.scan_parquet.html), which returns a
 [LazyFrame](https://docs.pola.rs/api/python/stable/reference/lazyframe/index.html).
 LazyFrames do not perform computations until necessary, so any filtering and transforms you apply to the data are
 deferred until an explicit

--- a/README.md
+++ b/README.md
@@ -1,4 +1,10 @@
-<mark style="background-color: #FFE331">**Below is a template of the README.md file for your hub. Italics in brackets are placeholders for information about your hub.**</mark>
+> [!NOTE]
+> To use this README.md in your hub, replace the placeholders (italics in
+> brackets) with information about your hub.
+> Below are a few example of READMEs throughout the Hubverse:
+>
+> - [FluSight Forecast Hub](https://github.com/cdcepi/FluSight-forecast-hub/blob/main/README.md)
+> - [US SARS-CoV-2 Variant Nowcast Hub](https://github.com/reichlab/variant-nowcast-hub)
 
 # *[Insert title of hub]*
 

--- a/README.md
+++ b/README.md
@@ -111,10 +111,11 @@ library(dplyr)
 library(hubData)
 
 hub_bucket <- s3_bucket([hub-bucket-name])
-hub_con <- hubData::connect_hub(hub_bucket, file_format="parquet", skip_checks=TRUE)
+hub_con <- hubData::connect_hub(hub_bucket, file_format = "parquet", skip_checks = TRUE)
 hub_con %>%
-  dplyr::filter(location=="MA", output_type=="quantile") %>%
+  dplyr::filter(location == "MA", output_type == "quantile") %>%
   hubData::collect_hub()
+
 ```
 
 - [full hubData documentation](https://hubverse-org.github.io/hubData/)

--- a/hub-config/admin.json
+++ b/hub-config/admin.json
@@ -12,5 +12,13 @@
         "name": "hubTemplate"
     },
     "file_format": ["csv", "parquet"],
-    "timezone": "US/Eastern"
+    "timezone": "US/Eastern",
+    "cloud": {
+        "enabled": true,
+        "host": {
+            "name": "aws",
+            "storage_service": "s3",
+            "storage_location": "hub-template"
+        }
+    }
 }


### PR DESCRIPTION
Closes #22

This is a first attempt at providing some template boilerplate for access hub data on S3.

Can be reviewed commit by commit.