### PR TITLE
Update links to docs.hubverse.io

### DIFF
--- a/README.md
+++ b/README.md
@@ -273,4 +273,4 @@ aws s3 cp s3://[hub-bucket-name]/[modeling-team-name]/UMass-flusion/ . --recursi
 ## Acknowledgments
 
 This repository follows the guidelines and standards outlined by [the
-[hubverse](https://hubverse.io/en/latest/), which provides a set of data formats and open source tools for modeling hubs.
+[hubverse](https://hubverse.io), which provides a set of data formats and open source tools for modeling hubs.

--- a/hub-config/README.md
+++ b/hub-config/README.md
@@ -1,3 +1,3 @@
 # Hub configuration files
 
-This folder should contain configuration files for the Hub, following the recommended [Hub configuration files in our documentation](https://hubverse.io/en/latest/user-guide/hub-config.html).
+This folder should contain configuration files for the Hub, following the recommended [Hub configuration files in our documentation](https://docs.hubverse.io/en/latest/user-guide/hub-config.html).

--- a/model-metadata/README.md
+++ b/model-metadata/README.md
@@ -4,7 +4,7 @@
 <mark style="background-color: #FFE331">**Below is a template of the README.md file for the model-metadata folder of your hub. Italics in brackets are placeholders for information about your hub. **</mark>
 
 
-This folder contains metadata files for the models submitting to the  *[hub name]*. The specification for these files has been adapted to be consistent with [model metadata guidelines in the hubverse documentation](https://hubverse.io/en/latest/user-guide/model-metadata.html).
+This folder contains metadata files for the models submitting to the  *[hub name]*. The specification for these files has been adapted to be consistent with [model metadata guidelines in the hubverse documentation](https://docs.hubverse.io/en/latest/user-guide/model-metadata.html).
 
 Each model is required to have metadata in 
 [yaml format](https://docs.ansible.com/ansible/latest/reference_appendices/YAMLSyntax.html).

--- a/model-output/README.md
+++ b/model-output/README.md
@@ -2,7 +2,7 @@
 
 <mark style="background-color: #FFE331">**Below is a template of the README.md file for the model-ouput folder of your hub. Italics in brackets are placeholders for information about your hub. **</mark>
 
-This folder contains a set of subdirectories, one for each model, that contains submitted model output files for that model. The structure of these directories and their contents follows [the model output guidelines in our documentation](https://hubverse.io/en/latest/user-guide/model-output.html). Documentation for hub submissions specifically is provided below. 
+This folder contains a set of subdirectories, one for each model, that contains submitted model output files for that model. The structure of these directories and their contents follows [the model output guidelines in our documentation](https://docs.hubverse.io/en/latest/user-guide/model-output.html). Documentation for hub submissions specifically is provided below. 
 
 # Data submission instructions
 


### PR DESCRIPTION
This PR updates `hubverse.io` URLs to point to `docs.hubverse.io`.

📝 Multiple commits — feel free to **Squash and Merge** to keep history clean.