### PR TITLE
applies relevant changes from old PR [Update S3 text #24]

### DIFF
--- a/README.md
+++ b/README.md
@@ -195,7 +195,7 @@ aws s3 cp s3://[hub-bucket-name]/target-data/ . --recursive --no-sign-request
 Download the model-output files for a specific team:
 
 ```sh
-aws s3 cp s3://[hub-bucket-name]/[modeling-team-name]/UMass-flusion/ . --recursive --no-sign-request
+aws s3 cp s3://[hub-bucket-name]/model-output/[modeling-team-name]/ . --recursive --no-sign-request
 ```
 
 - [Full documentation for `aws s3 ls`](https://docs.aws.amazon.com/cli/latest/reference/s3/ls.html)


### PR DESCRIPTION
The old PR [Update S3 text #24](https://github.com/hubverse-org/hubTemplate/pull/24) has changes that pre-date the hubdata Python package. I found only one line that was not obsolete, which this PR carries over.